### PR TITLE
remove unused force parameter

### DIFF
--- a/src/odig_main.ml
+++ b/src/odig_main.ml
@@ -44,7 +44,7 @@ let odoc_gen conf
   =
   Log.app (fun m -> m "Updating documentation, this may take some time...");
   Odig_odoc.gen
-    conf ~force ~index_title ~index_intro ~index_toc ~pkg_deps ~tag_index pkgs
+    conf ~index_title ~index_intro ~index_toc ~pkg_deps ~tag_index pkgs
 
 (* Commands *)
 

--- a/src/odig_odoc.ml
+++ b/src/odig_odoc.ml
@@ -463,7 +463,7 @@ let write_log_file c memo =
   B00_cli.Memo.Log.(write (Conf.b0_log_file c) (of_memo memo))
 
 let gen
-    c ~force ~index_title ~index_intro ~index_toc ~pkg_deps ~tag_index
+    c ~index_title ~index_intro ~index_toc ~pkg_deps ~tag_index
     pkgs_todo
   =
   Result.bind (Conf.memo c) @@ fun m ->

--- a/src/odig_odoc.mli
+++ b/src/odig_odoc.mli
@@ -12,11 +12,11 @@
 open Odig_support
 
 val gen :
-  Conf.t -> force:bool -> index_title:string option ->
+  Conf.t -> index_title:string option ->
   index_intro:B00_std.Fpath.t option -> index_toc:B00_std.Fpath.t option ->
   pkg_deps:bool -> tag_index:bool ->
   Pkg.t list -> (unit, string) result
-(** [gen c ~force ~index_intro ~pkg_deps ~tag_index pkgs]
+(** [gen c ~index_intro ~pkg_deps ~tag_index pkgs]
     generates API reference for packages [pkgs].
     {ul
     {- [index_title] is the title of the page


### PR DESCRIPTION
I was reading the code and noticed that, except if I miss something, the `~force` parameter is not used in `Odig_odoc.gen`.

This PR just removes it.